### PR TITLE
Fix install with mbstring

### DIFF
--- a/mailparse.c
+++ b/mailparse.c
@@ -30,7 +30,7 @@
 #include "php_open_temporary_file.h"
 
 /* just in case the config check doesn't enable mbstring automatically */
-#if !HAVE_MBSTRING
+#if !defined(MBFL_MBFILTER_H) && !defined(HAVE_MBSTRING)
 #error The mailparse extension requires the mbstring extension!
 #endif
 


### PR DESCRIPTION
Hello,

Fix this issue
https://bugs.php.net/bug.php?id=71813

On a fresh install of Ubuntu 17.10
```
sudo apt install php7.1-cli php-pear php-dev php-mbstring
sudo pecl install mailparse
[sudo] Mot de passe de exorus : 
WARNING: channel "pecl.php.net" has updated its protocols, use "pecl channel-update pecl.php.net" to update
downloading mailparse-3.0.2.tgz ...
Starting to download mailparse-3.0.2.tgz (38,206 bytes)
..........done: 38,206 bytes
10 source files, building
running: phpize
Configuring for:
PHP Api Version:         20160303
Zend Module Api No:      20160303
Zend Extension Api No:   320160303
building in /tmp/pear/temp/pear-build-rooteSkhbA/mailparse-3.0.2
running: /tmp/pear/temp/mailparse/configure --with-php-config=/usr/bin/php-config
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for a sed that does not truncate output... /bin/sed
checking for cc... cc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether cc accepts -g... yes
checking for cc option to accept ISO C89... none needed
checking how to run the C preprocessor... cc -E
checking for icc... no
checking for suncc... no
checking whether cc understands -c and -o together... yes
checking for system library directory... lib
checking if compiler supports -R... no
checking if compiler supports -Wl,-rpath,... yes
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking target system type... x86_64-pc-linux-gnu
checking for PHP prefix... /usr
checking for PHP includes... -I/usr/include/php/20160303 -I/usr/include/php/20160303/main -I/usr/include/php/20160303/TSRM -I/usr/include/php/20160303/Zend -I/usr/include/php/20160303/ext -I/usr/include/php/20160303/ext/date/lib
checking for PHP extension directory... /usr/lib/php/20160303
checking for PHP installed headers prefix... /usr/include/php/20160303
checking if debug is enabled... no
checking if zts is enabled... no
checking for re2c... no
configure: WARNING: You will need re2c 0.13.4 or later if you want to regenerate PHP parsers.
checking for gawk... no
checking for nawk... nawk
checking if nawk is broken... no
checking whether to enable mailparse support... yes, shared
checking how to print strings... printf
checking for a sed that does not truncate output... (cached) /bin/sed
checking for fgrep... /bin/grep -F
checking for ld used by cc... /usr/bin/ld
checking if the linker (/usr/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/bin/ld option to reload object files... -r
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for ar... ar
checking for archiver @FILE support... @
checking for strip... strip
checking for ranlib... ranlib
checking for gawk... (cached) nawk
checking command to parse /usr/bin/nm -B output from cc object... ok
checking for sysroot... no
checking for a working dd... /bin/dd
checking how to truncate binary pipes... /bin/dd bs=4096 count=1
checking for mt... mt
checking if mt is a manifest tool... no
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if cc supports -fno-rtti -fno-exceptions... no
checking for cc option to produce PIC... -fPIC -DPIC
checking if cc PIC flag -fPIC -DPIC works... yes
checking if cc static flag -static works... yes
checking if cc supports -c -o file.o... yes
checking if cc supports -c -o file.o... (cached) yes
checking whether the cc linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... no
configure: creating ./config.status
config.status: creating config.h
config.status: executing libtool commands
running: make
/bin/bash /tmp/pear/temp/pear-build-rooteSkhbA/mailparse-3.0.2/libtool --mode=compile cc  -I. -I/tmp/pear/temp/mailparse -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rooteSkhbA/mailparse-3.0.2/include -I/tmp/pear/temp/pear-build-rooteSkhbA/mailparse-3.0.2/main -I/tmp/pear/temp/mailparse -I/usr/include/php/20160303 -I/usr/include/php/20160303/main -I/usr/include/php/20160303/TSRM -I/usr/include/php/20160303/Zend -I/usr/include/php/20160303/ext -I/usr/include/php/20160303/ext/date/lib  -DHAVE_CONFIG_H  -g -O2   -c /tmp/pear/temp/mailparse/mailparse.c -o mailparse.lo
libtool: compile:  cc -I. -I/tmp/pear/temp/mailparse -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-rooteSkhbA/mailparse-3.0.2/include -I/tmp/pear/temp/pear-build-rooteSkhbA/mailparse-3.0.2/main -I/tmp/pear/temp/mailparse -I/usr/include/php/20160303 -I/usr/include/php/20160303/main -I/usr/include/php/20160303/TSRM -I/usr/include/php/20160303/Zend -I/usr/include/php/20160303/ext -I/usr/include/php/20160303/ext/date/lib -DHAVE_CONFIG_H -g -O2 -c /tmp/pear/temp/mailparse/mailparse.c  -fPIC -DPIC -o .libs/mailparse.o
/tmp/pear/temp/mailparse/mailparse.c:34:2: error: #error The mailparse extension requires the mbstring extension!
 #error The mailparse extension requires the mbstring extension!
  ^~~~~
Makefile:200 : la recette pour la cible « mailparse.lo » a échouée
make: *** [mailparse.lo] Erreur 1
ERROR: `make' failed

```