### PR TITLE
Fix errors when running tests because the required mbstring extension was not found

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -3,3 +3,30 @@ $(top_srcdir)/ext/mailparse/php_mailparse_rfc822.c: $(top_srcdir)/ext/mailparse/
 
 $(srcdir)/php_mailparse_rfc822.c: $(srcdir)/php_mailparse_rfc822.re
 	re2c -b $(srcdir)/php_mailparse_rfc822.re > $@
+
+test: all
+	@if test ! -z "$(PHP_EXECUTABLE)" && test -x "$(PHP_EXECUTABLE)"; then \
+		INI_FILE=`$(PHP_EXECUTABLE) -d 'display_errors=stderr' -r 'echo php_ini_loaded_file();' 2> /dev/null`; \
+		if test "$$INI_FILE"; then \
+			$(EGREP) -h -v $(PHP_DEPRECATED_DIRECTIVES_REGEX) "$$INI_FILE" > $(top_builddir)/tmp-php.ini; \
+		else \
+			echo > $(top_builddir)/tmp-php.ini; \
+		fi; \
+		INI_SCANNED_PATH=`$(PHP_EXECUTABLE) -d 'display_errors=stderr' -r '$$a = explode(",\n", trim(php_ini_scanned_files())); echo $$a[0];' 2> /dev/null`; \
+		if test "$$INI_SCANNED_PATH"; then \
+			INI_SCANNED_PATH=`$(top_srcdir)/build/shtool path -d $$INI_SCANNED_PATH`; \
+			$(EGREP) -h -v $(PHP_DEPRECATED_DIRECTIVES_REGEX) "$$INI_SCANNED_PATH"/*.ini >> $(top_builddir)/tmp-php.ini; \
+		fi; \
+		if test -f "$(top_builddir)/php.ini.fragment"; then \
+			cat $(top_builddir)/php.ini.fragment >> $(top_builddir)/tmp-php.ini; \
+		fi; \
+		TEST_PHP_EXECUTABLE=$(PHP_EXECUTABLE) \
+		TEST_PHP_SRCDIR=$(top_srcdir) \
+		CC="$(CC)" \
+			$(PHP_EXECUTABLE) -n -c $(top_builddir)/tmp-php.ini $(PHP_TEST_SETTINGS) $(top_srcdir)/run-tests.php -n -c $(top_builddir)/tmp-php.ini -d extension_dir=$(top_builddir)/modules/ $(PHP_TEST_SHARED_EXTENSIONS) $(TESTS); \
+		TEST_RESULT_EXIT_CODE=$$?; \
+		rm $(top_builddir)/tmp-php.ini; \
+		exit $$TEST_RESULT_EXIT_CODE; \
+	else \
+		echo "ERROR: Cannot run tests without CLI sapi."; \
+	fi

--- a/config.m4
+++ b/config.m4
@@ -18,6 +18,7 @@ required_ext=$php_ext_dir/mbstring.so
 if test -f "$required_ext"; then
 	CFLAGS="$CFLAGS -DHAVE_MBSTRING"
 	AC_MSG_RESULT(yes)
+	echo "extension=$required_ext" > $ext_builddir/php.ini.fragment
 else
 	AC_MSG_ERROR(no)
 fi

--- a/config.m4
+++ b/config.m4
@@ -10,3 +10,14 @@ if test "$PHP_MAILPARSE" != "no"; then
   PHP_ADD_EXTENSION_DEP(mailparse, mbstring, true)
   PHP_ADD_MAKEFILE_FRAGMENT
 fi
+
+AC_MSG_CHECKING(for installed php mbstring extension)
+php_ext_dir=$(php-config --extension-dir)
+required_ext=$php_ext_dir/mbstring.so
+
+if test -f "$required_ext"; then
+	CFLAGS="$CFLAGS -DHAVE_MBSTRING"
+	AC_MSG_RESULT(yes)
+else
+	AC_MSG_ERROR(no)
+fi


### PR DESCRIPTION
Makefile.frag now contains a copy of the target 'test' of Makefile.global, because it needs some modifications.