### PR TITLE
Replace ulong with zend_ulong

### DIFF
--- a/mailparse.c
+++ b/mailparse.c
@@ -1379,7 +1379,7 @@ static void add_attr_header_to_zval(char *valuelabel, char *attrprefix, zval *re
 	HashPosition pos;
 	zval *val;
 	char *newkey;
-	ulong num_index;
+	zend_ulong num_index;
 	zend_string *str_key;
 
 	zend_hash_internal_pointer_reset_ex(Z_ARRVAL_P(&attr->attributes), &pos);
@@ -1390,7 +1390,7 @@ static void add_attr_header_to_zval(char *valuelabel, char *attrprefix, zval *re
     if (str_key) {
       spprintf(&newkey, 0, "%s%s", attrprefix, ZSTR_VAL(str_key));
     } else {
-      spprintf(&newkey, 0, "%s%lu", attrprefix, num_index);
+      spprintf(&newkey, 0, "%s" ZEND_ULONG_FMT, attrprefix, num_index);
     }
     add_assoc_string(return_value, newkey, Z_STRVAL_P(val));
     efree(newkey);

--- a/php_mailparse_mime.c
+++ b/php_mailparse_mime.c
@@ -975,7 +975,7 @@ PHP_MAILPARSE_API void php_mimepart_remove_from_parent(php_mimepart *part)
 		if ((childpart_z = zend_hash_get_current_data_ex(&parent->children, &pos)) != NULL) {
 			mailparse_fetch_mimepart_resource(childpart, childpart_z);
 			if (childpart == part) {
-				ulong h;
+				zend_ulong h;
 				zend_hash_get_current_key_ex(&parent->children, NULL, &h, &pos);
 				zend_hash_index_del(&parent->children, h);
 				break;


### PR DESCRIPTION
`ulong` is no longer supported on Windows as of PHP 7.4.0, so we
replace it with the more suitable `zend_ulong`, and fix the format
specifier right away.