### PR TITLE
Fix #74233: Parsing multi Content-Disposition causes memory leak

### DIFF
--- a/php_mailparse_mime.c
+++ b/php_mailparse_mime.c
@@ -495,6 +495,10 @@ static int php_mimepart_process_header(php_mimepart *part)
 			}
 		}
 		if (strcmp(header_key, "content-disposition") == 0) {
+			if (part->content_disposition) {
+				php_mimeheader_free(part->content_disposition);
+				part->content_disposition = NULL;
+			}
 			part->content_disposition = php_mimeheader_alloc_from_tok(toks);
 		}
 

--- a/tests/bug74223.phpt
+++ b/tests/bug74223.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Fix #74233 (Parsing multi Content-Disposition causes memory leak)
+--SKIPIF--
+<?php
+if (!extension_loaded("mailparse")) die("skip mailparse extension not available");
+?>
+--FILE--
+<?php
+$msg = <<<EOD
+Subject:
+To: root@example.com
+mime-version: 1.0
+Content-Type: multipart/mixed; boundary="=___BOUNDARY___"
+
+--=___BOUNDARY___
+Content-Type: text/plain; charset=ISO-2022-JP
+Content-Transfer-Encoding: 7bit
+
+
+--=___BOUNDARY___
+Content-Type: text/plain; name="test.txt"
+Content-Disposition: attachment; filename="test.txt"
+Content-Disposition: attachment; filename="test2.txt"
+Content-Transfer-Encoding: base64
+
+dGVzdA==
+
+--=___BOUNDARY___--
+
+EOD;
+
+new MimeMessage('var', $msg) !== false;
+?>
+--EXPECT--


### PR DESCRIPTION
We need to free existing `content_disposition` before assigning a new
one.

This patch has been contributed by naoki-kawamukai.