### PR TITLE
Fix #81422: Potential double-free in mailparse_uudecode_all()

### DIFF
--- a/mailparse.c
+++ b/mailparse.c
@@ -831,13 +831,13 @@ PHP_FUNCTION(mailparse_uudecode_all)
 				array_init(&item);
 				add_assoc_string(&item, "filename", ZSTR_VAL(outpath));
 				add_next_index_zval(return_value, &item);
+				zend_string_release(outpath);
 			}
 
 			/* add an item */
 			array_init(&item);
 			add_assoc_string(&item, "origfilename", origfilename);
 
-			zend_string_release(outpath);
 			/* create a temp file for the data */
 			partstream = _mailparse_create_stream(&outpath);
 			if (partstream)	{
@@ -848,8 +848,8 @@ PHP_FUNCTION(mailparse_uudecode_all)
 				/* decode it */
 				mailparse_do_uudecode(instream, partstream);
 				php_stream_close(partstream);
+				zend_string_release(outpath);
 			}
-			zend_string_release(outpath);
 		} else {
 			/* write to the output file */
 			php_stream_write_string(outstream, buffer);

--- a/tests/bug81422.phpt
+++ b/tests/bug81422.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug #81422 (Potential double-free in mailparse_uudecode_all())
+--SKIPIF--
+<?php
+if (!extension_loaded("mailparse")) die("skip mailparse extension not available");
+?>
+--FILE--
+<?php
+$data = <<<'EOD'
+begin 644 foo
+`
+end
+
+begin 644 bar
+`
+end
+
+EOD;
+$stream = fopen('php://memory', 'w+');
+fwrite($stream, $data);
+rewind($stream);
+$parsed = mailparse_uudecode_all($stream);
+var_dump(count($parsed));
+?>
+--EXPECT--
+int(3)


### PR DESCRIPTION
We must not release the outpath multiple times.  We also make sure that
we only release the outpath of the part files, if the stream had been
opened successfully.