### PR TITLE
Fix #73110: Mails with unknown MIME version are treated as plain/text

### DIFF
--- a/php_mailparse_mime.c
+++ b/php_mailparse_mime.c
@@ -656,8 +656,12 @@ static int php_mimepart_process_line(php_mimepart *workpart)
 			--workpart->nbodylines;
 
 			/* some broken mailers include the content-type header but not a mime-version header.
+			 * some others may use a MIME version other than 1.0.
 			 * Let's relax and pretend they said they were mime 1.0 compatible */
-			if (workpart->mime_version == NULL && workpart->content_type != NULL) {
+			if (!IS_MIME_1(workpart) && workpart->content_type != NULL) {
+				if (workpart->mime_version != NULL) {
+					efree(workpart->mime_version);
+				}
 				workpart->mime_version = estrdup("1.0");
 			}
 

--- a/tests/bug73110.phpt
+++ b/tests/bug73110.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Bug #73110 (Mails with unknown MIME version are treated as plain/text)
+--SKIPIF--
+<?php
+if (!extension_loaded("mailparse")) die("skip mailparse extension not available");
+?>
+--FILE--
+<?php
+$text = 'Mime-Version: 1.0;
+Content-Type: multipart/Alternative; boundary="=====1473780076CSSSMTP_CLIENT=="
+
+--=====1473780076CSSSMTP_CLIENT==
+Content-Type: text/plain
+
+Hello please pay attached invoice
+--=====1473780076CSSSMTP_CLIENT==
+Content-Type: text/html; charset=utf-8
+
+Hello please pay attached invoice
+
+--=====1473780076CSSSMTP_CLIENT==--';
+$stream = fopen('php://memory', 'r+');
+fwrite($stream, $text);
+fseek($stream, 0);
+$resource = mailparse_msg_create();
+mailparse_msg_parse($resource, fread($stream, 10000));
+$data = mailparse_msg_get_part_data(mailparse_msg_get_part($resource, 1));
+var_dump($data['content-type']);
+mailparse_msg_free($resource);
+?>
+--EXPECT--
+string(21) "multipart/alternative"


### PR DESCRIPTION
We are already liberal regarding a missing MIME version header, but not
for versions other than 1.0.  However, there are no other MIME
versions, and it is somewhat unlikely that there ever will[1].  Thus,
we treat an unknown MIME version like we treat a missing MIME version,
i.e. we assume 1.0.

[1] <https://wellecks.wordpress.com/tag/mime-version/>