### PR TITLE
Building and testing on php 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   ubuntu:
     strategy:
       matrix:
-          version: ['7.3', '7.4', '8.0', '8.1', '8.2']
+          version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     runs-on: ubuntu-latest
     steps:
       - name: Install re2c


### PR DESCRIPTION
Just wondering if the PHP GitHub actions already works with PHP 8.3 rc, and if the extension would build