### PR TITLE
Update ci.yml to build mailparse for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,18 +65,15 @@ jobs:
           nmake
       - name: patch test ini
         run: |
-          # Get-ChildItem -Recurse
           if ("${{matrix.arch}}" -eq "x64") {$my_ini_file = "x64\Release_TS\tmp-php.ini"} else {$my_ini_file = "Release_TS\tmp-php.ini"}
-          # $mbstring = "mbstring"
           # $mbstring = "${{steps.setup-php.outputs.prefix}}\ext\mbstring.dll"
-          $mbstring = "D:\a\pecl-mail-mailparse\pecl-mail-mailparse\php-bin\ext\php_mbstring.dll"
+          $currentDir = pwd
+          $mbstring = "$currentDir\php-bin\ext\php_mbstring.dll"
           $content = [System.IO.File]::ReadAllText($my_ini_file)
           $pattern = [regex]"\nextension="
           $content = $pattern.replace($content, "`nextension=$mbstring`nextension=", 1)
           [System.IO.File]::WriteAllText($my_ini_file, $content)
           type $my_ini_file
-          Write-Output "${{steps.setup-php.outputs.prefix}}"
-          Write-Output "${{steps.setup-php.outputs}}"
       - name: package
         run: |
           md binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,7 @@ jobs:
           Get-ChildItem -Recurse
           if ("${{matrix.ts}}" -eq "ts") {$releaseDir = "Release_TS"} else {$releaseDir = "Release"}
           if ("${{matrix.arch}}" -eq "x64") {$my_ini_file = "x64\$releaseDir\tmp-php.ini"} else {$my_ini_file = "$releaseDir\tmp-php.ini"}
-          if ("${{matrix.version}}" -eq "7.4") {$my_ini_file = "php-sdk\bin\php\php.ini"}
-          # $mbstring = "${{steps.setup-php.outputs.prefix}}\ext\mbstring.dll"
+          if ("${{matrix.version}}".Substring(0, 1) -eq "7") {Copy-Item -Path php-sdk\bin\php\php.ini -Destination php.ini; $my_ini_file = "php.ini"}
           $currentDir = pwd
           $mbstring = "$currentDir\php-bin\ext\php_mbstring.dll"
           $content = [System.IO.File]::ReadAllText($my_ini_file)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,8 @@ jobs:
           nmake
       - name: patch test ini
         run: |
-          if ("${{matrix.arch}}" -eq "x64") {$my_ini_file = "x64\Release_TS\tmp-php.ini"} else {$my_ini_file = "Release_TS\tmp-php.ini"}
+          if ("${{matrix.ts}}" -eq "ts") {$releaseDir = "Release_TS"} else {$releaseDir = "Release"}
+          if ("${{matrix.arch}}" -eq "x64") {$my_ini_file = "x64\$releaseDir\tmp-php.ini"} else {$my_ini_file = "$releaseDir\tmp-php.ini"}
           # $mbstring = "${{steps.setup-php.outputs.prefix}}\ext\mbstring.dll"
           $currentDir = pwd
           $mbstring = "$currentDir\php-bin\ext\php_mbstring.dll"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           php-version: ${{matrix.version}}
           extensions: mbstring
-          tool: phpize, php-config
+          tools: phpize, php-config
       - name: phpize
         run: phpize
       - name: configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,7 @@ jobs:
           nmake
       - name: patch test ini
         run: |
-          if "${{matrix.arch}}"=="x64" (
-            set my_ini_file=x64\Release_TS\tmp-php.ini
-          ) else (
-            set my_ini_file=Release_TS\tmp-php.ini
-          )
+          if "${{matrix.arch}}"=="x64" (set my_ini_file=x64\Release_TS\tmp-php.ini) else (set my_ini_file=Release_TS\tmp-php.ini)
           set mbstring=${{steps.setup-php.outputs.prefix}}\ext\php_mbstring.dll
           sed -i "1s/^/extension=%mbstring:\=\\\%\n/" %my_ini_file%
           type %my_ini_file%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,10 @@ jobs:
         with:
           arch: ${{matrix.arch}}
           toolset: ${{steps.setup-php-sdk.outputs.toolset}}
-      - name: Build mailparse for Windows
-        run: |
-          phpize
-          ./configure --enable-test-ini --enable-mailparse --with-prefix=${{steps.setup-php-sdk.outputs.prefix}}
-          nmake
+      - name: phpize
+        run: phpize
+      - name: configure
+        run: configure --enable-test-ini --enable-mailparse --with-prefix=${{steps.setup-php.outputs.prefix}}
       - name: patch test ini
         run: |
           if ("${{matrix.ts}}" -eq "ts") {$releaseDir = "Release_TS"} else {$releaseDir = "Release"}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install re2c
         run: sudo apt-get install -y re2c
       - name: Checkout mailparse
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -30,7 +30,7 @@ jobs:
           export TEST_PHP_ARGS="-n -d extension=mbstring.so -d extension=modules/mailparse.so"
           php run-tests.php -P --show-diff tests
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -60,8 +60,18 @@ jobs:
       - name: Build mailparse for Windows
         run: |
           phpize
-          ./configure --enable-mailparse --with-prefix=${{steps.setup-php-sdk.outputs.prefix}}
+          ./configure --enable-test-ini --enable-mailparse --with-prefix=${{steps.setup-php-sdk.outputs.prefix}}
           nmake
+      - name: patch test ini
+        run: |
+          if "${{matrix.arch}}"=="x64" (
+            set my_ini_file=x64\Release_TS\tmp-php.ini
+          ) else (
+            set my_ini_file=Release_TS\tmp-php.ini
+          )
+          set mbstring=${{steps.setup-php.outputs.prefix}}\ext\php_mbstring.dll
+          sed -i "1s/^/extension=%mbstring:\=\\\%\n/" %my_ini_file%
+          type %my_ini_file%
       - name: package
         run: |
           md binaries
@@ -72,4 +82,4 @@ jobs:
           name: mailparse-${{matrix.version}}-${{matrix.arch}}-${{matrix.ts}}
           path: binaries
       - name: test
-        run: nmake test TESTS="-d extension=${{steps.setup-php-sdk.outputs.prefix}}\ext\php_mbstring.dll --show-diff tests"
+        run: nmake test TESTS="--show-diff tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,23 +30,24 @@ jobs:
           export TEST_PHP_ARGS="-n -d extension=mbstring.so -d extension=modules/mailparse.so"
           php run-tests.php -P --show-diff tests
   windows:
-    defaults:
-      run:
-        shell: cmd
-    strategy:
-      matrix:
-          version: ["7.4", "8.0"]
-          arch: [x64, x86]
-          ts: [ts]
     runs-on: windows-latest
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+          version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
+          arch: [x64, x86]
+          ts: [nts, ts]
     steps:
       - name: Configure Git
         run: git config --global core.autocrlf false
       - name: Checkout mailparse
-        uses: actions/checkout@v2
-      - name: Setup PHP
-        id: setup-php
-        uses: cmb69/setup-php-sdk@v0.2
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup PHP ${{ matrix.version }}
+        id: setup-php-sdk
+        uses: php/setup-php-sdk@v0.8
         with:
           version: ${{matrix.version}}
           arch: ${{matrix.arch}}
@@ -55,12 +56,20 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{matrix.arch}}
-          toolset: ${{steps.setup-php.outputs.toolset}}
-      - name: phpize
-        run: phpize
-      - name: configure
-        run: configure --enable-mailparse --with-prefix=${{steps.setup-php.outputs.prefix}}
-      - name: make
-        run: nmake
+          toolset: ${{steps.setup-php-sdk.outputs.toolset}}
+      - name: Build mailparse for Windows
+        run: |
+          phpize
+          ./configure --enable-mailparse --with-prefix=${{steps.setup-php-sdk.outputs.prefix}}
+          nmake
+      - name: package
+        run: |
+          md binaries
+          Get-ChildItem -Recurse -Filter "php_mailparse.dll" | ForEach-Object {Copy-Item -Path $_.FullName -Destination "binaries"}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mailparse-${{matrix.version}}-${{matrix.arch}}-${{matrix.ts}}
+          path: binaries
       - name: test
-        run: nmake test TESTS="-d extension=${{steps.setup-php.outputs.prefix}}\ext\php_mbstring.dll --show-diff tests"
+        run: nmake test TESTS="-d extension=${{steps.setup-php-sdk.outputs.prefix}}\ext\php_mbstring.dll --show-diff tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           nmake
       - name: patch test ini
         run: |
+          Get-ChildItem -Recurse
           if ("${{matrix.ts}}" -eq "ts") {$releaseDir = "Release_TS"} else {$releaseDir = "Release"}
           if ("${{matrix.arch}}" -eq "x64") {$my_ini_file = "x64\$releaseDir\tmp-php.ini"} else {$my_ini_file = "$releaseDir\tmp-php.ini"}
           # $mbstring = "${{steps.setup-php.outputs.prefix}}\ext\mbstring.dll"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,8 @@ jobs:
           nmake
       - name: patch test ini
         run: |
-          ls -l x64\Release_TS\
           if ("${{matrix.arch}}" -eq "x64") {$my_ini_file = "x64\Release_TS\tmp-php.ini"} else {$my_ini_file = "Release_TS\tmp-php.ini"}
-          $mbstring = "${{steps.setup-php.outputs.prefix}}\ext\php_mbstring.dll"
+          $mbstring = "mbstring"
           $content = [System.IO.File]::ReadAllText($my_ini_file)
           $pattern = [regex]"\nextension="
           $content = $pattern.replace($content, "`nextension=$mbstring`nextension=", 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
           Get-ChildItem -Recurse
           if ("${{matrix.ts}}" -eq "ts") {$releaseDir = "Release_TS"} else {$releaseDir = "Release"}
           if ("${{matrix.arch}}" -eq "x64") {$my_ini_file = "x64\$releaseDir\tmp-php.ini"} else {$my_ini_file = "$releaseDir\tmp-php.ini"}
+          if ("${{matrix.version}}" -eq "7.4") {$my_ini_file = "php-sdk\bin\php\php.ini"}
           # $mbstring = "${{steps.setup-php.outputs.prefix}}\ext\mbstring.dll"
           $currentDir = pwd
           $mbstring = "$currentDir\php-bin\ext\php_mbstring.dll"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,13 @@ jobs:
           nmake
       - name: patch test ini
         run: |
+          Write-Output ${{steps.setup-php.outputs.prefix}} 
+          Write-Output ${{steps.setup-php.outputs}} 
           Get-ChildItem -Recurse
           if ("${{matrix.arch}}" -eq "x64") {$my_ini_file = "x64\Release_TS\tmp-php.ini"} else {$my_ini_file = "Release_TS\tmp-php.ini"}
           # $mbstring = "mbstring"
-          $mbstring = "${{steps.setup-php.outputs.prefix}}\ext\mbstring.dll"
+          # $mbstring = "${{steps.setup-php.outputs.prefix}}\ext\mbstring.dll"
+          $mbstring = "D:\a\pecl-mail-mailparse\pecl-mail-mailparse\php-bin\ext\php_mbstring.dll"
           $content = [System.IO.File]::ReadAllText($my_ini_file)
           $pattern = [regex]"\nextension="
           $content = $pattern.replace($content, "`nextension=$mbstring`nextension=", 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   ubuntu:
     strategy:
       matrix:
-          version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+          version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     runs-on: ubuntu-latest
     steps:
       - name: Install re2c
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
+          version: ["8.2", "8.3", "8.4"]
           arch: [x64, x86]
           ts: [nts, ts]
     steps:
@@ -57,10 +57,11 @@ jobs:
         with:
           arch: ${{matrix.arch}}
           toolset: ${{steps.setup-php-sdk.outputs.toolset}}
-      - name: phpize
-        run: phpize
-      - name: configure
-        run: ./configure --enable-test-ini --enable-mailparse --with-prefix=${{steps.setup-php.outputs.prefix}}
+      - name: Build mailparse for Windows
+        run: |
+          phpize
+          ./configure --enable-test-ini --enable-mailparse --with-prefix=${{steps.setup-php-sdk.outputs.prefix}}
+          nmake
       - name: patch test ini
         run: |
           if ("${{matrix.ts}}" -eq "ts") {$releaseDir = "Release_TS"} else {$releaseDir = "Release"}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          version: ["8.2", "8.3", "8.4"]
+          version: ["8.2", "8.3"]
           arch: [x64, x86]
           ts: [nts, ts]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,13 @@ jobs:
           nmake
       - name: patch test ini
         run: |
-          if ("${{matrix.arch}}" -eq "x64") {set my_ini_file=x64\Release_TS\tmp-php.ini} else {set my_ini_file=Release_TS\tmp-php.ini}
-          set mbstring=${{steps.setup-php.outputs.prefix}}\ext\php_mbstring.dll
-          sed -i "1s/^/extension=%mbstring:\=\\\%\n/" %my_ini_file%
-          type %my_ini_file%
+          if ("${{matrix.arch}}" -eq "x64") {$my_ini_file = "x64\Release_TS\tmp-php.ini"} else {$my_ini_file = "Release_TS\tmp-php.ini"}
+          $mbstring = "${{steps.setup-php.outputs.prefix}}\ext\php_mbstring.dll"
+          $content = [System.IO.File]::ReadAllText("$my_ini_file")
+          $pattern = [regex]"\nextension="
+          $content = $pattern.replace($content, "`nextension=$mbstring`nextension=", 1)
+          [System.IO.File]::WriteAllText($my_ini_file, $content)
+          type $my_ini_file
       - name: package
         run: |
           md binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: phpize
         run: phpize
       - name: configure
-        run: configure --enable-test-ini --enable-mailparse --with-prefix=${{steps.setup-php.outputs.prefix}}
+        run: ./configure --enable-test-ini --enable-mailparse --with-prefix=${{steps.setup-php.outputs.prefix}}
       - name: patch test ini
         run: |
           if ("${{matrix.ts}}" -eq "ts") {$releaseDir = "Release_TS"} else {$releaseDir = "Release"}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           nmake
       - name: patch test ini
         run: |
-          if "${{matrix.arch}}"=="x64" (set my_ini_file=x64\Release_TS\tmp-php.ini) else (set my_ini_file=Release_TS\tmp-php.ini)
+          if ("${{matrix.arch}}"=="x64") {set my_ini_file=x64\Release_TS\tmp-php.ini} else {set my_ini_file=Release_TS\tmp-php.ini}
           set mbstring=${{steps.setup-php.outputs.prefix}}\ext\php_mbstring.dll
           sed -i "1s/^/extension=%mbstring:\=\\\%\n/" %my_ini_file%
           type %my_ini_file%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           nmake
       - name: patch test ini
         run: |
-          if ("${{matrix.arch}}"=="x64") {set my_ini_file=x64\Release_TS\tmp-php.ini} else {set my_ini_file=Release_TS\tmp-php.ini}
+          if ("${{matrix.arch}}" -eq "x64") {set my_ini_file=x64\Release_TS\tmp-php.ini} else {set my_ini_file=Release_TS\tmp-php.ini}
           set mbstring=${{steps.setup-php.outputs.prefix}}\ext\php_mbstring.dll
           sed -i "1s/^/extension=%mbstring:\=\\\%\n/" %my_ini_file%
           type %my_ini_file%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,10 @@ jobs:
           nmake
       - name: patch test ini
         run: |
+          Get-ChildItem -Recurse
           if ("${{matrix.arch}}" -eq "x64") {$my_ini_file = "x64\Release_TS\tmp-php.ini"} else {$my_ini_file = "Release_TS\tmp-php.ini"}
-          $mbstring = "mbstring"
+          # $mbstring = "mbstring"
+          $mbstring = "${{steps.setup-php.outputs.prefix}}\ext\mbstring.dll"
           $content = [System.IO.File]::ReadAllText($my_ini_file)
           $pattern = [regex]"\nextension="
           $content = $pattern.replace($content, "`nextension=$mbstring`nextension=", 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
+          #version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
+          version: ["7.4", "8.3"]
           arch: [x64, x86]
           ts: [nts, ts]
     steps:
@@ -64,9 +65,10 @@ jobs:
           nmake
       - name: patch test ini
         run: |
+          ls -l x64\Release_TS\
           if ("${{matrix.arch}}" -eq "x64") {$my_ini_file = "x64\Release_TS\tmp-php.ini"} else {$my_ini_file = "Release_TS\tmp-php.ini"}
           $mbstring = "${{steps.setup-php.outputs.prefix}}\ext\php_mbstring.dll"
-          $content = [System.IO.File]::ReadAllText("$my_ini_file")
+          $content = [System.IO.File]::ReadAllText($my_ini_file)
           $pattern = [regex]"\nextension="
           $content = $pattern.replace($content, "`nextension=$mbstring`nextension=", 1)
           [System.IO.File]::WriteAllText($my_ini_file, $content)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,7 @@ jobs:
           nmake
       - name: patch test ini
         run: |
-          Write-Output ${{steps.setup-php.outputs.prefix}} 
-          Write-Output ${{steps.setup-php.outputs}} 
-          Get-ChildItem -Recurse
+          # Get-ChildItem -Recurse
           if ("${{matrix.arch}}" -eq "x64") {$my_ini_file = "x64\Release_TS\tmp-php.ini"} else {$my_ini_file = "Release_TS\tmp-php.ini"}
           # $mbstring = "mbstring"
           # $mbstring = "${{steps.setup-php.outputs.prefix}}\ext\mbstring.dll"
@@ -77,6 +75,8 @@ jobs:
           $content = $pattern.replace($content, "`nextension=$mbstring`nextension=", 1)
           [System.IO.File]::WriteAllText($my_ini_file, $content)
           type $my_ini_file
+          Write-Output "${{steps.setup-php.outputs.prefix}}"
+          Write-Output "${{steps.setup-php.outputs}}"
       - name: package
         run: |
           md binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          #version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
-          version: ["7.4", "8.3"]
+          version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
           arch: [x64, x86]
           ts: [nts, ts]
     steps:
@@ -65,10 +64,8 @@ jobs:
           nmake
       - name: patch test ini
         run: |
-          Get-ChildItem -Recurse
           if ("${{matrix.ts}}" -eq "ts") {$releaseDir = "Release_TS"} else {$releaseDir = "Release"}
           if ("${{matrix.arch}}" -eq "x64") {$my_ini_file = "x64\$releaseDir\tmp-php.ini"} else {$my_ini_file = "$releaseDir\tmp-php.ini"}
-          if ("${{matrix.version}}".Substring(0, 1) -eq "7") {Copy-Item -Path php-sdk\bin\php\php.ini -Destination php.ini; $my_ini_file = "php.ini"}
           $currentDir = pwd
           $mbstring = "$currentDir\php-bin\ext\php_mbstring.dll"
           $content = [System.IO.File]::ReadAllText($my_ini_file)


### PR DESCRIPTION
This PR modifies the ci.yml to build mailparse for Windows (x86 and x64) 
It includes the build process for php versions from 7.4 up to 8.3. 
The Windows artifacts are uploaded for each version.
#36 