### PR TITLE
fixes #20

### DIFF
--- a/mailparse.c
+++ b/mailparse.c
@@ -1511,7 +1511,7 @@ static int mailparse_get_part_data(php_mimepart *part, zval *return_value)
 
 	if ((tmpval = zend_hash_find(Z_ARRVAL_P(&headers), hash_key)) != NULL) {
 		zval *content_id = tmpval;
-		char *id, *open, *close;
+		char *id, *close;
 		size_t len;
 
 		/* Handle multiple Content-ID headers (stored as array) */
@@ -1522,23 +1522,27 @@ static int mailparse_get_part_data(php_mimepart *part, zval *return_value)
 		if (content_id != NULL && Z_TYPE_P(content_id) == IS_STRING) {
 			/* Extract content-id value directly instead of parsing it as an
 			 * RFC 822 address, which incorrectly strips parenthesized text
-			 * as comments (GH-20). Extract the msg-id between '<' and '>'
-			 * if present, otherwise return the trimmed value as-is. */
+			 * as comments (GH-20). Trim whitespace, then strip angle brackets
+			 * only when '<' is the first character; otherwise return as-is. */
 			id = Z_STRVAL_P(content_id);
 			len = Z_STRLEN_P(content_id);
 
-			open = memchr(id, '<', len);
-			if (open) {
-				close = memchr(open + 1, '>', len - (open - id) - 1);
+			while (len > 0 && (id[0] == ' ' || id[0] == '\t')) { id++; len--; }
+			while (len > 0 && (id[len-1] == ' ' || id[len-1] == '\t')) { len--; }
+
+			if (len >= 2 && id[0] == '<') {
+				close = memchr(id + 1, '>', len - 1);
 				if (close) {
-					add_assoc_stringl(return_value, "content-id", open + 1, close - open - 1);
+					add_assoc_stringl(return_value, "content-id", id + 1, close - id - 1);
 				} else {
+					/* Malformed: '<' without '>' — skip the '<' and trim */
+					id++;
+					len--;
+					while (len > 0 && (id[0] == ' ' || id[0] == '\t')) { id++; len--; }
+					while (len > 0 && (id[len-1] == ' ' || id[len-1] == '\t')) { len--; }
 					add_assoc_stringl(return_value, "content-id", id, len);
 				}
 			} else {
-				/* No angle brackets — trim whitespace and return as-is */
-				while (len > 0 && (id[0] == ' ' || id[0] == '\t')) { id++; len--; }
-				while (len > 0 && (id[len-1] == ' ' || id[len-1] == '\t')) { len--; }
 				add_assoc_stringl(return_value, "content-id", id, len);
 			}
 		}

--- a/mailparse.c
+++ b/mailparse.c
@@ -1527,8 +1527,13 @@ static int mailparse_get_part_data(php_mimepart *part, zval *return_value)
 			id = Z_STRVAL_P(content_id);
 			len = Z_STRLEN_P(content_id);
 
-			while (len > 0 && (id[0] == ' ' || id[0] == '\t')) { id++; len--; }
-			while (len > 0 && (id[len-1] == ' ' || id[len-1] == '\t')) { len--; }
+			while (len > 0 && (id[0] == ' ' || id[0] == '\t')) {
+				id++;
+				len--;
+			}
+			while (len > 0 && (id[len-1] == ' ' || id[len-1] == '\t')) {
+				len--;
+			}
 
 			if (len >= 2 && id[0] == '<') {
 				close = memchr(id + 1, '>', len - 1);
@@ -1538,8 +1543,13 @@ static int mailparse_get_part_data(php_mimepart *part, zval *return_value)
 					/* Malformed: '<' without '>' — skip the '<' and trim */
 					id++;
 					len--;
-					while (len > 0 && (id[0] == ' ' || id[0] == '\t')) { id++; len--; }
-					while (len > 0 && (id[len-1] == ' ' || id[len-1] == '\t')) { len--; }
+					while (len > 0 && (id[0] == ' ' || id[0] == '\t')) {
+						id++;
+						len--;
+					}
+					while (len > 0 && (id[len-1] == ' ' || id[len-1] == '\t')) {
+						len--;
+					}
 					add_assoc_stringl(return_value, "content-id", id, len);
 				}
 			} else {

--- a/mailparse.c
+++ b/mailparse.c
@@ -1461,7 +1461,7 @@ static int mailparse_get_part_data(php_mimepart *part, zval *return_value)
 	zval headers, *tmpval;
 	off_t startpos, endpos, bodystart;
 	int nlines, nbodylines;
-	/* extract the address part of the content-id only */
+	/* extract the content-id value */
 	zend_string *hash_key = zend_string_init("content-id", sizeof("content-id") - 1, 0);
 
 	array_init(return_value);
@@ -1520,10 +1520,10 @@ static int mailparse_get_part_data(php_mimepart *part, zval *return_value)
 		}
 
 		if (content_id != NULL && Z_TYPE_P(content_id) == IS_STRING) {
-			/* Extract content-id value directly instead of parsing it as an
-			 * RFC 822 address, which incorrectly strips parenthesized text
-			 * as comments (GH-20). Trim whitespace, then strip angle brackets
-			 * only when '<' is the first character; otherwise return as-is. */
+			/* Extract the Content-ID value directly. Trim surrounding
+			 * horizontal whitespace, and if the first non-whitespace
+			 * character is '<', return the text up to the first '>';
+			 * otherwise return the trimmed value unchanged (GH-20). */
 			id = Z_STRVAL_P(content_id);
 			len = Z_STRLEN_P(content_id);
 

--- a/mailparse.c
+++ b/mailparse.c
@@ -1510,15 +1510,19 @@ static int mailparse_get_part_data(php_mimepart *part, zval *return_value)
 		add_assoc_string(return_value, "content-boundary", part->boundary);
 
 	if ((tmpval = zend_hash_find(Z_ARRVAL_P(&headers), hash_key)) != NULL) {
-		php_rfc822_tokenized_t *toks;
-		php_rfc822_addresses_t *addrs;
+		/* Extract content-id value directly instead of parsing it as an
+		 * RFC 822 address, which incorrectly strips parenthesized text
+		 * as comments (GH-20). Just strip angle brackets if present. */
+		char *id = Z_STRVAL_P(tmpval);
+		size_t len = Z_STRLEN_P(tmpval);
 
-		toks = php_mailparse_rfc822_tokenize(Z_STRVAL_P(tmpval), 1);
-		addrs = php_rfc822_parse_address_tokens(toks);
-		if (addrs->naddrs > 0)
-			add_assoc_string(return_value, "content-id", addrs->addrs[0].address);
-		php_rfc822_free_addresses(addrs);
-		php_rfc822_tokenize_free(toks);
+		while (len > 0 && (id[0] == ' ' || id[0] == '\t')) { id++; len--; }
+		while (len > 0 && (id[len-1] == ' ' || id[len-1] == '\t')) { len--; }
+		if (len >= 2 && id[0] == '<' && id[len-1] == '>') {
+			add_assoc_stringl(return_value, "content-id", id + 1, len - 2);
+		} else {
+			add_assoc_stringl(return_value, "content-id", id, len);
+		}
 	}
 	zend_string_release(hash_key);
 

--- a/mailparse.c
+++ b/mailparse.c
@@ -1510,18 +1510,37 @@ static int mailparse_get_part_data(php_mimepart *part, zval *return_value)
 		add_assoc_string(return_value, "content-boundary", part->boundary);
 
 	if ((tmpval = zend_hash_find(Z_ARRVAL_P(&headers), hash_key)) != NULL) {
-		/* Extract content-id value directly instead of parsing it as an
-		 * RFC 822 address, which incorrectly strips parenthesized text
-		 * as comments (GH-20). Just strip angle brackets if present. */
-		char *id = Z_STRVAL_P(tmpval);
-		size_t len = Z_STRLEN_P(tmpval);
+		zval *content_id = tmpval;
+		char *id, *open, *close;
+		size_t len;
 
-		while (len > 0 && (id[0] == ' ' || id[0] == '\t')) { id++; len--; }
-		while (len > 0 && (id[len-1] == ' ' || id[len-1] == '\t')) { len--; }
-		if (len >= 2 && id[0] == '<' && id[len-1] == '>') {
-			add_assoc_stringl(return_value, "content-id", id + 1, len - 2);
-		} else {
-			add_assoc_stringl(return_value, "content-id", id, len);
+		/* Handle multiple Content-ID headers (stored as array) */
+		if (Z_TYPE_P(content_id) == IS_ARRAY) {
+			content_id = zend_hash_index_find(Z_ARRVAL_P(content_id), 0);
+		}
+
+		if (content_id != NULL && Z_TYPE_P(content_id) == IS_STRING) {
+			/* Extract content-id value directly instead of parsing it as an
+			 * RFC 822 address, which incorrectly strips parenthesized text
+			 * as comments (GH-20). Extract the msg-id between '<' and '>'
+			 * if present, otherwise return the trimmed value as-is. */
+			id = Z_STRVAL_P(content_id);
+			len = Z_STRLEN_P(content_id);
+
+			open = memchr(id, '<', len);
+			if (open) {
+				close = memchr(open + 1, '>', len - (open - id) - 1);
+				if (close) {
+					add_assoc_stringl(return_value, "content-id", open + 1, close - open - 1);
+				} else {
+					add_assoc_stringl(return_value, "content-id", id, len);
+				}
+			} else {
+				/* No angle brackets — trim whitespace and return as-is */
+				while (len > 0 && (id[0] == ' ' || id[0] == '\t')) { id++; len--; }
+				while (len > 0 && (id[len-1] == ' ' || id[len-1] == '\t')) { len--; }
+				add_assoc_stringl(return_value, "content-id", id, len);
+			}
 		}
 	}
 	zend_string_release(hash_key);

--- a/tests/gh20.phpt
+++ b/tests/gh20.phpt
@@ -1,0 +1,58 @@
+--TEST--
+GH issue #20 (Unexpected parsed value of content-id with parentheses)
+--SKIPIF--
+<?php
+if (!extension_loaded("mailparse")) die("skip mailparse extension not available");
+?>
+--FILE--
+<?php
+$mime = "Content-Type: image/png\r\n" .
+    "Content-Transfer-Encoding: base64\r\n" .
+    "Content-ID: <Facebook_32x32(1)_aa284ba9-f148-4698-9c1f-c8e92bdb842e.png>\r\n" .
+    "\r\n" .
+    "iVBOR\r\n";
+
+$resource = mailparse_msg_create();
+mailparse_msg_parse($resource, $mime);
+
+$part = mailparse_msg_get_part($resource, 1);
+$data = mailparse_msg_get_part_data($part);
+
+echo "content-id: " . $data['content-id'] . "\n";
+
+/* Also test bare content-id without angle brackets */
+$mime2 = "Content-Type: image/png\r\n" .
+    "Content-Transfer-Encoding: base64\r\n" .
+    "Content-ID: Facebook_32x32(1)_test.png\r\n" .
+    "\r\n" .
+    "iVBOR\r\n";
+
+$resource2 = mailparse_msg_create();
+mailparse_msg_parse($resource2, $mime2);
+
+$part2 = mailparse_msg_get_part($resource2, 1);
+$data2 = mailparse_msg_get_part_data($part2);
+
+echo "content-id bare: " . $data2['content-id'] . "\n";
+
+/* Standard RFC-compliant content-id */
+$mime3 = "Content-Type: image/png\r\n" .
+    "Content-ID: <part1@example.com>\r\n" .
+    "\r\n" .
+    "iVBOR\r\n";
+
+$resource3 = mailparse_msg_create();
+mailparse_msg_parse($resource3, $mime3);
+
+$part3 = mailparse_msg_get_part($resource3, 1);
+$data3 = mailparse_msg_get_part_data($part3);
+
+echo "content-id rfc: " . $data3['content-id'] . "\n";
+
+echo "ok\n";
+?>
+--EXPECT--
+content-id: Facebook_32x32(1)_aa284ba9-f148-4698-9c1f-c8e92bdb842e.png
+content-id bare: Facebook_32x32(1)_test.png
+content-id rfc: part1@example.com
+ok

--- a/tests/gh20.phpt
+++ b/tests/gh20.phpt
@@ -63,6 +63,21 @@ $data4 = mailparse_msg_get_part_data($part4);
 
 echo "content-id trailing comment: " . $data4['content-id'] . "\n";
 
+/* Duplicate Content-ID headers (stored as array internally) */
+$mime5 = "Content-Type: image/png\r\n" .
+    "Content-ID: <first@example.com>\r\n" .
+    "Content-ID: <second@example.com>\r\n" .
+    "\r\n" .
+    "iVBOR\r\n";
+
+$resource5 = mailparse_msg_create();
+mailparse_msg_parse($resource5, $mime5);
+
+$part5 = mailparse_msg_get_part($resource5, 1);
+$data5 = mailparse_msg_get_part_data($part5);
+
+echo "content-id duplicate: " . $data5['content-id'] . "\n";
+
 echo "ok\n";
 ?>
 --EXPECT--
@@ -70,4 +85,5 @@ content-id: Facebook_32x32(1)_aa284ba9-f148-4698-9c1f-c8e92bdb842e.png
 content-id bare: Facebook_32x32(1)_test.png
 content-id rfc: part1@example.com
 content-id trailing comment: part1@example.com
+content-id duplicate: first@example.com
 ok

--- a/tests/gh20.phpt
+++ b/tests/gh20.phpt
@@ -49,10 +49,25 @@ $data3 = mailparse_msg_get_part_data($part3);
 
 echo "content-id rfc: " . $data3['content-id'] . "\n";
 
+/* RFC-compliant content-id with trailing comment */
+$mime4 = "Content-Type: image/png\r\n" .
+    "Content-ID: <part1@example.com> (comment)\r\n" .
+    "\r\n" .
+    "iVBOR\r\n";
+
+$resource4 = mailparse_msg_create();
+mailparse_msg_parse($resource4, $mime4);
+
+$part4 = mailparse_msg_get_part($resource4, 1);
+$data4 = mailparse_msg_get_part_data($part4);
+
+echo "content-id trailing comment: " . $data4['content-id'] . "\n";
+
 echo "ok\n";
 ?>
 --EXPECT--
 content-id: Facebook_32x32(1)_aa284ba9-f148-4698-9c1f-c8e92bdb842e.png
 content-id bare: Facebook_32x32(1)_test.png
 content-id rfc: part1@example.com
+content-id trailing comment: part1@example.com
 ok


### PR DESCRIPTION
## Fix Content-ID parsing stripping parenthesized text (GH-20)

Fixes #20

### Problem

`mailparse_msg_get_part_data()` returns the wrong `content-id` value when the Content-ID header contains parentheses. For example:

```
Content-ID: <Facebook_32x32(1)_aa284ba9-f148-4698-9c1f-c8e92bdb842e.png>
```

Returns `Facebook_32x32 _aa284ba9-f148-4698-9c1f-c8e92bdb842e.png` instead of the correct `Facebook_32x32(1)_aa284ba9-f148-4698-9c1f-c8e92bdb842e.png`.

The code was passing the Content-ID value through the RFC 822 address tokenizer (`php_mailparse_rfc822_tokenize` + `php_rfc822_parse_address_tokens`), which interprets parenthesized text as RFC 822 comments and strips them. Content-ID is a message identifier, not an email address, so full address parsing is inappropriate here.

### Fix

Replace the RFC 822 address parser with simple whitespace trimming and angle bracket stripping. This preserves the existing behavior for standard RFC-compliant Content-IDs like `<part1@example.com>` (angle brackets removed, inner value returned) while fixing the bug for values containing parentheses.