### PR TITLE
More Windows CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           php-version: ${{matrix.version}}
           extensions: mbstring
-          tool: phpize, php-config
+          tools: phpize, php-config
       - name: phpize
         run: phpize
       - name: configure
@@ -38,7 +38,7 @@ jobs:
       matrix:
           version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
           arch: [x64, x86]
-          ts: [ts]
+          ts: [ts, nts]
     runs-on: windows-latest
     steps:
       - name: Checkout mailparse
@@ -65,3 +65,8 @@ jobs:
         run: |
           set PATH=%PATH%;${{steps.setup-php.outputs.prefix}}\ext
           nmake test TESTS="-d extension=${{steps.setup-php.outputs.prefix}}\ext\php_mbstring.dll --show-diff tests"
+      - name: Upload DLL
+        uses: actions/upload-artifact@v4
+        with:
+          name: php_mailparse-${{matrix.version}}-${{matrix.arch}}-${{matrix.ts}}
+          path: "**\\php_mailparse.dll"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,8 @@ jobs:
           set PATH=%PATH%;${{steps.setup-php.outputs.prefix}}\ext
           nmake test TESTS="-d extension=${{steps.setup-php.outputs.prefix}}\ext\php_mbstring.dll --show-diff tests"
       - name: Upload DLL
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: php_mailparse-${{matrix.version}}-${{matrix.arch}}-${{matrix.ts}}
-          path: "**\\php_mailparse.dll"
+          path: "**/php_mailparse.dll"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           set PATH=%PATH%;${{steps.setup-php.outputs.prefix}}\ext
           nmake test TESTS="-d extension=${{steps.setup-php.outputs.prefix}}\ext\php_mbstring.dll --show-diff tests"
       - name: Upload DLL
-        if: success() || failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: php_mailparse-${{matrix.version}}-${{matrix.arch}}-${{matrix.ts}}


### PR DESCRIPTION
## CI: Add NTS builds, DLL artifacts, and fix tools typo

Supersedes #39

### Changes

- **Add NTS to Windows matrix**: Test both thread-safe and non-thread-safe builds (was TS only)
- **Upload built DLLs as artifacts**: Each Windows build uploads `php_mailparse.dll` for easy download
- **Fix `tool` → `tools` typo**: Correct the parameter name for `shivammathur/setup-php` on Ubuntu