### PR TITLE
Fix out-of-bounds read on malformed uuencode "begin" line

### DIFF
--- a/mailparse.c
+++ b/mailparse.c
@@ -528,10 +528,14 @@ PHP_METHOD(mimemessage, extract_uue)
 
 			/* parse out the file name.
 			 * The next 4 bytes are an octal number for perms; ignore it */
-			origfilename = &buffer[10];
+			/* The filename starts after "begin <mode> ". Guard against
+			 * a short "begin" line so we don't index past the NUL
+			 * terminator into stack garbage. */
+			len = strlen(buffer);
+			origfilename = &buffer[len > 10 ? 10 : len];
 			/* NUL terminate the filename */
 			len = strlen(origfilename);
-			while(isspace(origfilename[len-1]))
+			while (len > 0 && isspace((unsigned char)origfilename[len-1]))
 				origfilename[--len] = '\0';
 
 			/* make the return an array */
@@ -618,10 +622,14 @@ PHP_METHOD(mimemessage, enum_uue)
 
 			/* parse out the file name.
 			 * The next 4 bytes are an octal number for perms; ignore it */
-			origfilename = &buffer[10];
+			/* The filename starts after "begin <mode> ". Guard against
+			 * a short "begin" line so we don't index past the NUL
+			 * terminator into stack garbage. */
+			len = strlen(buffer);
+			origfilename = &buffer[len > 10 ? 10 : len];
 			/* NUL terminate the filename */
 			len = strlen(origfilename);
-			while(isspace(origfilename[len-1]))
+			while (len > 0 && isspace((unsigned char)origfilename[len-1]))
 				origfilename[--len] = '\0';
 
 			/* make the return an array */
@@ -812,10 +820,14 @@ PHP_FUNCTION(mailparse_uudecode_all)
 
 			/* parse out the file name.
 			 * The next 4 bytes are an octal number for perms; ignore it */
-			origfilename = &buffer[10];
+			/* The filename starts after "begin <mode> ". Guard against
+			 * a short "begin" line so we don't index past the NUL
+			 * terminator into stack garbage. */
+			len = strlen(buffer);
+			origfilename = &buffer[len > 10 ? 10 : len];
 			/* NUL terminate the filename */
 			len = strlen(origfilename);
-			while(isspace(origfilename[len-1]))
+			while (len > 0 && isspace((unsigned char)origfilename[len-1]))
 				origfilename[--len] = '\0';
 
 			/* make the return an array */


### PR DESCRIPTION
The three uudecode loops (`mailparse_msg_extract_uue`, `_enum_uue`, `mailparse_uudecode_all`) matched a 6-byte `begin ` prefix and then read the filename unconditionally at `buffer[10]`, assuming a `begin <mode> <name>` layout. A short line such as `begin 644\n` (strlen 10) puts `buffer[10]` at or past the NUL terminator, reading into stack garbage; the trailing-whitespace trim could also underflow to `origfilename[-1]` on an empty filename. Both are reachable from attacker-controlled message bodies.

Clamp the filename offset to the actual line length (`&buffer[len > 10 ? 10 : len]`), guard the trim loop with `len > 0`, and cast the `isspace()` argument to `unsigned char`.
