### PR TITLE
Fix arg zval leak in extract_callback_user_func

### DIFF
--- a/mailparse.c
+++ b/mailparse.c
@@ -1209,19 +1209,19 @@ static int extract_callback_user_func(php_mimepart *part, zval *userfunc, const 
 
 	if (zend_fcall_info_init(userfunc, 0, &fci, &fcc, NULL, NULL) == FAILURE) {
 		zend_error(E_WARNING, "%s(): unable to call user function", get_active_function_name());
+		zval_ptr_dtor(&arg);
 		return 0;
 	}
 
 	zend_fcall_info_argn(&fci, 1, &arg);
 	fci.retval = &retval;
-	if (zend_call_function(&fci, &fcc)) {
-		zend_fcall_info_args_clear(&fci, 1);
+	if (zend_call_function(&fci, &fcc) == SUCCESS) {
+		zval_ptr_dtor(&retval);
+	} else {
 		zend_error(E_WARNING, "%s(): unable to call user function", get_active_function_name());
-		return 0;
 	}
 
 	zend_fcall_info_args_clear(&fci, 1);
-	zval_ptr_dtor(&retval);
 	zval_ptr_dtor(&arg);
 
 	return 0;


### PR DESCRIPTION
`extract_callback_user_func` ZVAL_STRINGL's each decoded chunk into `arg` but only freed it on the success path. Both early returns leaked one `zend_string` per chunk: `zend_fcall_info_init()` failure (reachable from userland by passing a non-callable as the callback) and `zend_call_function()` failure. `zend_fcall_info_argn()` takes its own reference via `ZVAL_COPY`, so the caller's `arg` always needs exactly one `zval_ptr_dtor`.

Release `arg` on every path; dtor `retval` only on the success path, where the engine has populated it.
