### PR TITLE
Use memchr for end-of-line scan in php_mimepart_parse

### DIFF
--- a/php_mailparse_mime.c
+++ b/php_mailparse_mime.c
@@ -743,12 +743,9 @@ PHP_MAILPARSE_API int php_mimepart_parse(php_mimepart *part, const char *buf, si
 
 	while(bufsize > 0) {
 		/* look for EOL */
-		for (len = 0; len < bufsize; len++)
-			if (buf[len] == '\n') {
-				break;
-			}
-		if (len < bufsize && buf[len] == '\n') {
-			++len;
+		const char *eol = memchr(buf, '\n', bufsize);
+		if (eol != NULL) {
+			len = (size_t)(eol - buf) + 1; /* include the '\n' */
 			smart_string_appendl(&part->parsedata.workbuf, buf, len);
 			if (php_mimepart_process_line(part) == FAILURE) {
 				/* php_mimepart_process_line() only returns FAILURE in case the count of children
@@ -765,6 +762,8 @@ PHP_MAILPARSE_API int php_mimepart_parse(php_mimepart *part, const char *buf, si
 			};
 			part->parsedata.workbuf.len = 0;
 		} else {
+			/* no EOL in this chunk: buffer the remainder for the next call */
+			len = bufsize;
 			smart_string_appendl(&part->parsedata.workbuf, buf, len);
 		}
 


### PR DESCRIPTION
`php_mimepart_parse` scans each input chunk for the next newline to split it into lines, which is the inner loop of all message parsing. Replaced the hand-rolled byte-at-a-time scan with `memchr` so libc can scan a machine word at a time. Behaviour is unchanged: a chunk with a newline is appended through the `\n` and handed to `php_mimepart_process_line`; a chunk without one is buffered for the next call.
