### PR TITLE
Limit MIME nesting depth to prevent unbounded recursion

### DIFF
--- a/php_mailparse_mime.c
+++ b/php_mailparse_mime.c
@@ -523,8 +523,18 @@ static int php_mimepart_process_header(php_mimepart *part)
 
 static php_mimepart *alloc_new_child_part(php_mimepart *parentpart, size_t startpos, int inherit)
 {
-	php_mimepart *child = php_mimepart_alloc();
+	php_mimepart *child;
+	php_mimepart *ancestor;
 	zval child_z;
+	int depth = 0;
+
+	for (ancestor = parentpart; ancestor != NULL; ancestor = ancestor->parent) {
+		if (++depth >= MAXLEVELS) {
+			return NULL;
+		}
+	}
+
+	child = php_mimepart_alloc();
 
 	parentpart->parsedata.lastpart = child;
 	child->parent = parentpart;
@@ -619,6 +629,10 @@ static int php_mimepart_process_line(php_mimepart *workpart)
 			}
 
 			newpart = alloc_new_child_part(workpart, workpart->endpos + origcount, 1);
+			if (newpart == NULL) {
+				php_error_docref(NULL, E_WARNING, "MIME message too deeply nested");
+				return FAILURE;
+			}
 			php_mimepart_update_positions(workpart, workpart->endpos + origcount, workpart->endpos + linelen, 1);
 			if (workpart->mime_version) {
 				newpart->mime_version = estrdup(workpart->mime_version);
@@ -716,6 +730,10 @@ static int php_mimepart_process_line(php_mimepart *workpart)
 
 			if (CONTENT_TYPE_IS(workpart, "message/rfc822")) {
 				workpart = alloc_new_child_part(workpart, workpart->bodystart, 0);
+				if (workpart == NULL) {
+					php_error_docref(NULL, E_WARNING, "MIME message too deeply nested");
+					return FAILURE;
+				}
 				workpart->parsedata.in_header = 1;
 				return SUCCESS;
 
@@ -724,6 +742,10 @@ static int php_mimepart_process_line(php_mimepart *workpart)
 			/* create a section for the preamble that precedes the first boundary */
 			if (workpart->boundary) {
 				workpart = alloc_new_child_part(workpart, workpart->bodystart, 1);
+				if (workpart == NULL) {
+					php_error_docref(NULL, E_WARNING, "MIME message too deeply nested");
+					return FAILURE;
+				}
 				workpart->parsedata.in_header = 0;
 				workpart->parsedata.is_dummy = 1;
 				return SUCCESS;

--- a/tests/mime_nesting_depth.phpt
+++ b/tests/mime_nesting_depth.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Deeply nested MIME parts are rejected instead of overflowing the stack
+--SKIPIF--
+<?php if (!extension_loaded("mailparse")) print "skip"; ?>
+--FILE--
+<?php
+$msg = str_repeat("Content-Type: message/rfc822\n\n", 1000);
+$m = mailparse_msg_create();
+var_dump(mailparse_msg_parse($m, $msg));
+/* walking the (capped) tree must not crash */
+mailparse_msg_get_structure($m);
+echo "done\n";
+mailparse_msg_free($m);
+?>
+--EXPECTF--
+Warning: mailparse_msg_parse(): MIME message too deeply nested in %s on line %d
+bool(false)
+done


### PR DESCRIPTION
mailparse never enforced a limit on MIME nesting depth. MAXLEVELS (20) has been defined but never referenced; the only structural check is MAXPARTS, which counts a single part's children and so never trips for a chain that nests one child per level. A message built from repeated "Content-Type: message/rfc822" parts, or singly-nested multipart containers, produces an arbitrarily deep tree. php_mimepart_enum_parts() walks that tree recursively, so mailparse_msg_get_structure(), mailparse_msg_get_part() and the extract paths overflow the C stack and crash. This enforces MAXLEVELS in alloc_new_child_part() and fails the parse once the limit is reached, the same way MAXPARTS is already handled.

Reproducer: mailparse_msg_get_structure() on a message of ~100k repeated "Content-Type: message/rfc822\n\n" parts segfaults before the fix.
