### PR TITLE
Fix out-of-bounds token read on trailing address delimiters

### DIFF
--- a/php_mailparse_rfc822.c
+++ b/php_mailparse_rfc822.c
@@ -547,7 +547,7 @@ mailbox:	/* addr-spec / phrase route-addr */
 			a_count = i - start_tok;
 			/* if an address is enclosed in <>, leave them out of the the
 			 * address value that we return */
-			if (toks->tokens[a_start].token == '<') {
+			if (a_count > 0 && toks->tokens[a_start].token == '<') {
 				a_start++;
 				a_count--;
 			}

--- a/php_mailparse_rfc822.re
+++ b/php_mailparse_rfc822.re
@@ -410,7 +410,7 @@ mailbox:	/* addr-spec / phrase route-addr */
 			a_count = i - start_tok;
 			/* if an address is enclosed in <>, leave them out of the the
 			 * address value that we return */
-			if (toks->tokens[a_start].token == '<') {
+			if (a_count > 0 && toks->tokens[a_start].token == '<') {
 				a_start++;
 				a_count--;
 			}

--- a/tests/addr_trailing_delim_oob.phpt
+++ b/tests/addr_trailing_delim_oob.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Trailing delimiters in an address list do not read past the token array
+--SKIPIF--
+<?php if (!extension_loaded("mailparse")) print "skip"; ?>
+--FILE--
+<?php
+$r = mailparse_rfc822_parse_addresses("a@b,,");
+var_dump($r[0]['address']);
+$r = mailparse_rfc822_parse_addresses("grp: a@b,,");
+var_dump($r[0]['is_group']);
+echo "done\n";
+?>
+--EXPECT--
+string(3) "a@b"
+bool(true)
+done


### PR DESCRIPTION
In parse_address_tokens(), a run of trailing ',' or ';' delimiters can advance start_tok to toks->ntokens. The addr-spec branch then reads toks->tokens[start_tok].token with start_tok equal to ntokens, one element past the ecalloc'd token array. This strips the enclosing <> only when the address span is non-empty (a_count > 0), which also keeps the index in bounds; the route-addr branch is already guarded by its own i < ntokens check. Applied to both the .re source and the generated .c.

Reproducer: mailparse_rfc822_parse_addresses("a@b,,").
