### PR TITLE
Fix memory leak of parameter name after an RFC2231 parameter

### DIFF
--- a/php_mailparse_mime.c
+++ b/php_mailparse_mime.c
@@ -198,6 +198,7 @@ static struct php_mimeheader_with_attributes *php_mimeheader_alloc_from_tok(php_
 				 *
 				 * Original rfc2231 support by IceWarp Ltd. <info@icewarp.com>
 				 */
+				currentencoded = 0;
 				check_name = strchr(name, '*');
 				if (check_name) {
 				  currentencoded = 1;

--- a/tests/rfc2231_plain_after_encoded.phpt
+++ b/tests/rfc2231_plain_after_encoded.phpt
@@ -1,0 +1,18 @@
+--TEST--
+A plain parameter following an RFC2231 (name*N) parameter is not leaked
+--SKIPIF--
+<?php if (!extension_loaded("mailparse")) print "skip"; ?>
+--FILE--
+<?php
+$m = mailparse_msg_create();
+mailparse_msg_parse($m, "Content-Type: x/y; a*0=\"foo\"; a*1=\"bar\"; b=\"baz\"\n\nbody\n");
+$d = mailparse_msg_get_part_data($m);
+var_dump($d['content-a']);
+var_dump($d['content-b']);
+mailparse_msg_free($m);
+echo "done\n";
+?>
+--EXPECT--
+string(6) "foobar"
+string(3) "baz"
+done


### PR DESCRIPTION
currentencoded was set to 1 on the first RFC2231 (name*N) parameter and never reset, so every later parameter took the is_rfc2231_name finalize branch. When a later plain parameter arrived, neither the !currentencoded branch (stale 1) nor the namechanged branch (stale 0) consumed it, so the recombined parameter name was neither stored nor freed. Resetting currentencoded per parameter routes the plain parameter back through the normal path, which stores and frees it.

Reproducer: parsing Content-Type: x/y; a*0="foo"; b="bar" leaks one allocation per plain parameter that follows an encoded one.
