### PR TITLE
Clean up dead declarations, const lookup table, and indentation

### DIFF
--- a/mailparse.c
+++ b/mailparse.c
@@ -1420,13 +1420,13 @@ static void add_attr_header_to_zval(char *valuelabel, char *attrprefix, zval *re
 
 		zend_hash_get_current_key_ex(Z_ARRVAL_P(&attr->attributes), &str_key, &num_index, &pos);
 
-    if (str_key) {
-      spprintf(&newkey, 0, "%s%s", attrprefix, ZSTR_VAL(str_key));
-    } else {
-      spprintf(&newkey, 0, "%s" ZEND_ULONG_FMT, attrprefix, num_index);
-    }
-    add_assoc_string(return_value, newkey, Z_STRVAL_P(val));
-    efree(newkey);
+		if (str_key) {
+			spprintf(&newkey, 0, "%s%s", attrprefix, ZSTR_VAL(str_key));
+		} else {
+			spprintf(&newkey, 0, "%s" ZEND_ULONG_FMT, attrprefix, num_index);
+		}
+		add_assoc_string(return_value, newkey, Z_STRVAL_P(val));
+		efree(newkey);
 
 		zend_hash_move_forward_ex(Z_ARRVAL_P(&attr->attributes), &pos);
 	}

--- a/mailparse_encoding.c
+++ b/mailparse_encoding.c
@@ -189,7 +189,7 @@ static int mb_filt_conv_base64dec(int c, mb_convert_filter *filter)
 	} else if (c == 0x2f) {			/* '/' */
 		n = 63;
 	} else {
-		/* Invalid character - output a marker but continue */
+		/* invalid character, ignored */
 		return 0;
 	}
 	n &= 0x3f;
@@ -246,7 +246,7 @@ static int mb_filt_conv_base64dec_flush(mb_convert_filter *filter)
  * Quoted-Printable encoding/decoding
  * ============================================================================= */
 
-static int hex2code_map[] = {
+static const int hex2code_map[] = {
 	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,

--- a/php_mailparse.h
+++ b/php_mailparse.h
@@ -47,13 +47,7 @@ PHP_FUNCTION(mailparse_msg_extract_whole_part_file);
 PHP_FUNCTION(mailparse_msg_create);
 PHP_FUNCTION(mailparse_msg_free);
 PHP_FUNCTION(mailparse_msg_parse);
-PHP_FUNCTION(mailparse_msg_parse_file);
 
-PHP_FUNCTION(mailparse_msg_find);
-PHP_FUNCTION(mailparse_msg_getstructure);
-PHP_FUNCTION(mailparse_msg_getinfo);
-PHP_FUNCTION(mailparse_msg_extract);
-PHP_FUNCTION(mailparse_msg_extract_file);
 PHP_FUNCTION(mailparse_rfc822_parse_addresses);
 PHP_FUNCTION(mailparse_determine_best_xfer_encoding);
 PHP_FUNCTION(mailparse_stream_encode);

--- a/php_mailparse_mime.c
+++ b/php_mailparse_mime.c
@@ -448,21 +448,21 @@ static int php_mimepart_process_header(php_mimepart *part)
 			efree(newstr);
 		} else {
 			if((zheaderval = zend_hash_find(Z_ARRVAL_P(&part->headerhash), header_zstring)) != NULL) {
-			      if(Z_TYPE_P(zheaderval) == IS_ARRAY) {
-          add_next_index_string(zheaderval, header_val);
-        } else {
-          /* Create a nested array if there is more than one of the same header */
-          zval zarr;
-          array_init(&zarr);
-          Z_ADDREF_P(zheaderval);
+				if (Z_TYPE_P(zheaderval) == IS_ARRAY) {
+					add_next_index_string(zheaderval, header_val);
+				} else {
+					/* Create a nested array if there is more than one of the same header */
+					zval zarr;
+					array_init(&zarr);
+					Z_ADDREF_P(zheaderval);
 
-          add_next_index_zval(&zarr, zheaderval);
-          add_next_index_string(&zarr, header_val);
-          add_assoc_zval(&part->headerhash, header_key, &zarr);
-        }
-      } else {
-        add_assoc_string(&part->headerhash, header_key, header_val);
-      }
+					add_next_index_zval(&zarr, zheaderval);
+					add_next_index_string(&zarr, header_val);
+					add_assoc_zval(&part->headerhash, header_key, &zarr);
+				}
+			} else {
+				add_assoc_string(&part->headerhash, header_key, header_val);
+			}
 		}
 		zend_string_release(header_zstring);
 		/* if it is useful, keep a pointer to it in the mime part */


### PR DESCRIPTION
Cosmetic cleanup, no behaviour change.

- `php_mailparse.h`: remove prototypes for five functions that are neither defined nor registered (`mailparse_msg_find`, `mailparse_msg_getstructure`, `mailparse_msg_getinfo`, `mailparse_msg_extract`, `mailparse_msg_extract_file`), plus the duplicate `mailparse_msg_parse_file` prototype.
- `mailparse_encoding.c`: mark the read-only `hex2code_map` lookup table `const` (it sits next to the already-const `mb_base64_table`), and drop the misleading "output a marker but continue" comment in the base64 decoder — the code just ignores the byte.
- Re-tab two space-indented blocks (`add_attr_header_to_zval` and the duplicate-header branch in `php_mimepart_process_header`) to match the surrounding tab indentation.
