### PR TITLE
Fix out-of-bounds read in RFC822 group/route-addr address parsing

### DIFF
--- a/php_mailparse_rfc822.c
+++ b/php_mailparse_rfc822.c
@@ -485,7 +485,7 @@ mailbox:	/* addr-spec / phrase route-addr */
 		;
 
 	/* the stuff from start_tok to i - 1 is the display name part */
-	if (addrs && !in_group && i - start_tok > 0) {
+	if (addrs && !in_group && i - start_tok > 0 && iaddr < addrs->naddrs) {
 		int j, has_comments = 0, has_strings = 0;
 		switch(i < toks->ntokens ? toks->tokens[i].token : 0) {
 			case ';': case ',': case '<':
@@ -561,9 +561,10 @@ mailbox:	/* addr-spec / phrase route-addr */
 	}
 
 	if (addrs && address_value) {
+		int slot_ok = iaddr < addrs->naddrs;
 
 		/* if no display name has been given, use the address */
-		if (addrs->addrs[iaddr].name == NULL) {
+		if (slot_ok && addrs->addrs[iaddr].name == NULL) {
 			addrs->addrs[iaddr].name = estrdup(address_value);
 		}
 
@@ -572,8 +573,10 @@ mailbox:	/* addr-spec / phrase route-addr */
 				smart_string_appendl(&group_addrs, ",", 1);
 			smart_string_appends(&group_addrs, address_value);
 			efree(address_value);
-		} else {
+		} else if (slot_ok) {
 			addrs->addrs[iaddr].address = address_value;
+		} else {
+			efree(address_value);
 		}
 		address_value = NULL;
 	}
@@ -586,7 +589,7 @@ mailbox:	/* addr-spec / phrase route-addr */
 	if ((start_tok < toks->ntokens && toks->tokens[start_tok].token == ';') || start_tok == toks->ntokens) {
 		/* end of group */
 
-		if (addrs) {
+		if (addrs && iaddr < addrs->naddrs) {
 			smart_string_appendl(&group_addrs, ";", 1);
 			smart_string_0(&group_addrs);
 			addrs->addrs[iaddr].address = estrdup(group_addrs.c);

--- a/php_mailparse_rfc822.re
+++ b/php_mailparse_rfc822.re
@@ -348,7 +348,7 @@ mailbox:	/* addr-spec / phrase route-addr */
 		;
 
 	/* the stuff from start_tok to i - 1 is the display name part */
-	if (addrs && !in_group && i - start_tok > 0) {
+	if (addrs && !in_group && i - start_tok > 0 && iaddr < addrs->naddrs) {
 		int j, has_comments = 0, has_strings = 0;
 		switch(i < toks->ntokens ? toks->tokens[i].token : 0) {
 			case ';': case ',': case '<':
@@ -424,9 +424,10 @@ mailbox:	/* addr-spec / phrase route-addr */
 	}
 
 	if (addrs && address_value) {
+		int slot_ok = iaddr < addrs->naddrs;
 
 		/* if no display name has been given, use the address */
-		if (addrs->addrs[iaddr].name == NULL) {
+		if (slot_ok && addrs->addrs[iaddr].name == NULL) {
 			addrs->addrs[iaddr].name = estrdup(address_value);
 		}
 
@@ -435,8 +436,10 @@ mailbox:	/* addr-spec / phrase route-addr */
 				smart_string_appendl(&group_addrs, ",", 1);
 			smart_string_appends(&group_addrs, address_value);
 			efree(address_value);
-		} else {
+		} else if (slot_ok) {
 			addrs->addrs[iaddr].address = address_value;
+		} else {
+			efree(address_value);
 		}
 		address_value = NULL;
 	}
@@ -449,7 +452,7 @@ mailbox:	/* addr-spec / phrase route-addr */
 	if ((start_tok < toks->ntokens && toks->tokens[start_tok].token == ';') || start_tok == toks->ntokens) {
 		/* end of group */
 
-		if (addrs) {
+		if (addrs && iaddr < addrs->naddrs) {
 			smart_string_appendl(&group_addrs, ";", 1);
 			smart_string_0(&group_addrs);
 			addrs->addrs[iaddr].address = estrdup(group_addrs.c);

--- a/tests/rfc822_group_routeaddr_oob.phpt
+++ b/tests/rfc822_group_routeaddr_oob.phpt
@@ -1,0 +1,20 @@
+--TEST--
+A route-addr inside a group does not read past the parsed address array
+--SKIPIF--
+<?php if (!extension_loaded("mailparse")) print "skip"; ?>
+--FILE--
+<?php
+/* A group whose inner mailbox is an unterminated route-addr ("<" with no ">")
+ * used to desync the counting and building passes of the address parser and
+ * index one slot past the end of the allocated address array. */
+foreach (array("<>:<", ":;:<", "a@b,<>:<") as $in) {
+	$r = mailparse_rfc822_parse_addresses($in);
+	var_dump(is_array($r));
+}
+echo "done\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+done


### PR DESCRIPTION
## What

`mailparse_rfc822_parse_addresses()` reads (and can write) one element past the end of the parsed address array on crafted input such as `<>:<` or `:;:<`.

The parser runs two passes: one with a NULL output to count addresses and size the array, then one to fill it. A group whose inner mailbox is an unterminated route-addr (`<` with no closing `>`) advances the token cursor past the group's `;`, so the two passes disagree on how many slots `iaddr` reaches. The fill pass then indexes `addrs->addrs[iaddr]` at `iaddr == naddrs`, one past the `ecalloc`'d array.

This is the sibling of the addr-spec case fixed by the recent `a_count > 0` guard; the group/route-addr path indexing the address array itself was never bounds-checked.

## Fix

Bound every fill-pass write to `addrs->addrs[iaddr]` by `iaddr < addrs->naddrs` (the count established by the first pass). On valid input the passes agree and the guard never fires; on the desyncing malformed input it drops the stray write instead of running off the array, and frees the orphaned `address_value` so nothing leaks.

Both `php_mailparse_rfc822.re` and the generated `php_mailparse_rfc822.c` carry the change, matching how this file is maintained.
