### PR TITLE
Fix memory leak when a plain parameter repeats an RFC2231 name

### DIFF
--- a/php_mailparse_mime.c
+++ b/php_mailparse_mime.c
@@ -267,6 +267,11 @@ static struct php_mimeheader_with_attributes *php_mimeheader_alloc_from_tok(php_
 						}
 
 						namechanged = 0;
+					} else if (name && name != name_buf) {
+						/* plain parameter repeating the active RFC2231 name
+						 * (a separate allocation from name_buf): free the name
+						 * that would otherwise leak */
+						efree(name);
 					}
 				} else {
 					add_assoc_string(&attr->attributes, name, value);

--- a/tests/rfc2231_duplicate_plain_name.phpt
+++ b/tests/rfc2231_duplicate_plain_name.phpt
@@ -1,0 +1,20 @@
+--TEST--
+A plain parameter repeating an RFC2231 encoded name does not leak the name
+--SKIPIF--
+<?php if (!extension_loaded("mailparse")) print "skip"; ?>
+--FILE--
+<?php
+/* "URL*0=a" opens an RFC2231 continuation named URL; the following plain
+ * "URL=b" repeats that base name. The duplicate name string used to leak. */
+$m = mailparse_msg_create();
+mailparse_msg_parse($m, "Content-Type: text/plain; URL*0=\"a\"; URL=\"b\"\r\n\r\nbody\r\n");
+$d = mailparse_msg_get_part_data($m);
+var_dump($d["content-type"]);
+var_dump($d["content-url"]);
+mailparse_msg_free($m);
+echo "done\n";
+?>
+--EXPECT--
+string(10) "text/plain"
+string(1) "a"
+done


### PR DESCRIPTION
## What

A plain MIME parameter whose name matches an active RFC2231 continuation leaks the parameter-name string. The leak size is the attacker-controlled name length and it repeats per occurrence, so a crafted header stream is a slow memory-exhaustion vector.

Example: `Content-Type: text/plain; URL*0="a"; URL="b"`. The `URL="b"` parameter shares the base name of the `URL*0` continuation; its emalloc'd name is neither stored nor freed.

## Fix

In `php_mimeheader_alloc_from_tok`, when the active RFC2231 name matches the new plain parameter, free the duplicate name. The guard is `name != name_buf` so it only frees a separate allocation, never the live `name_buf` that the first encoded parameter aliases (which would be a use-after-free on the next iteration).
