### PR TITLE
Fix memory leaks in mailparse_uudecode_all

### DIFF
--- a/mailparse.c
+++ b/mailparse.c
@@ -794,7 +794,7 @@ PHP_FUNCTION(mailparse_uudecode_all)
 {
 	zval *file, item;
 	char *buffer = NULL;
-	zend_string *outpath;
+	zend_string *outpath, *partpath = NULL;
 	int nparts = 0;
 	php_stream *instream, *outstream = NULL, *partstream = NULL;
 
@@ -839,6 +839,7 @@ PHP_FUNCTION(mailparse_uudecode_all)
 				add_assoc_string(&item, "filename", ZSTR_VAL(outpath));
 				add_next_index_zval(return_value, &item);
 				zend_string_release(outpath);
+				outpath = NULL;
 			}
 
 			/* add an item */
@@ -846,16 +847,19 @@ PHP_FUNCTION(mailparse_uudecode_all)
 			add_assoc_string(&item, "origfilename", origfilename);
 
 			/* create a temp file for the data */
-			partstream = _mailparse_create_stream(&outpath);
+			partstream = _mailparse_create_stream(&partpath);
 			if (partstream)	{
 				nparts++;
-				add_assoc_string(&item, "filename", ZSTR_VAL(outpath));
+				add_assoc_string(&item, "filename", ZSTR_VAL(partpath));
 				add_next_index_zval(return_value, &item);
 
 				/* decode it */
 				mailparse_do_uudecode(instream, partstream);
 				php_stream_close(partstream);
-				zend_string_release(outpath);
+				zend_string_release(partpath);
+			} else {
+				/* temp-file creation failed: drop the half-built item */
+				zval_ptr_dtor(&item);
 			}
 		} else {
 			/* write to the output file */
@@ -867,7 +871,14 @@ PHP_FUNCTION(mailparse_uudecode_all)
 	efree(buffer);
 
 	if (nparts == 0) {
-		/* delete temporary file */
+		/* no uuencoded part decoded: release the unused initial temp-file
+		 * path, or discard the partially-built array if a begin line was seen
+		 * but every part failed to decode */
+		if (outpath) {
+			zend_string_release(outpath);
+		} else {
+			zval_ptr_dtor(return_value);
+		}
 		RETURN_FALSE;
 	}
 }

--- a/tests/uudecode_all_no_begin.phpt
+++ b/tests/uudecode_all_no_begin.phpt
@@ -1,0 +1,17 @@
+--TEST--
+mailparse_uudecode_all on input without a "begin" line does not leak
+--SKIPIF--
+<?php if (!extension_loaded("mailparse")) print "skip"; ?>
+--FILE--
+<?php
+/* With no "begin" line the temp-file path string was never released. */
+$fp = fopen("php://memory", "r+");
+fwrite($fp, "plain text\nno uuencoded data here\n");
+rewind($fp);
+var_dump(mailparse_uudecode_all($fp));
+fclose($fp);
+echo "done\n";
+?>
+--EXPECT--
+bool(false)
+done


### PR DESCRIPTION
## What

`mailparse_uudecode_all()` leaks in two cases:

1. Input with no `begin ` line never releases the initial temp-file path `zend_string` (allocated up front, released only inside the first-`begin` branch). Any non-uuencoded stream triggers it.
2. If per-part temp-file creation fails, the half-built `item` array zval is never inserted into the result nor freed.

## Fix

Track the initial path in its own variable and NULL it once released, then release it at the tail if no `begin` line was seen. Give the per-part stream its own `partpath` variable so the initial path is never clobbered. Free the `item` on the temp-file-failure branch, and discard the partial result array if a `begin` was seen but every part failed.
