### PR TITLE
Fix MimeMessage::extract_uue() ignoring index greater than zero

### DIFF
--- a/mailparse.c
+++ b/mailparse.c
@@ -559,6 +559,7 @@ PHP_METHOD(mimemessage, extract_uue)
 			} else {
 				/* skip that part */
 				mailparse_do_uudecode(srcstream, NULL);
+				nparts++;
 			}
 		} else {
 			if (php_stream_tell(srcstream) >= end)

--- a/tests/extract_uue_multiple_parts.phpt
+++ b/tests/extract_uue_multiple_parts.phpt
@@ -1,0 +1,26 @@
+--TEST--
+MimeMessage::extract_uue() can extract uuencoded parts past the first
+--SKIPIF--
+<?php if (!extension_loaded("mailparse")) print "skip"; ?>
+--FILE--
+<?php
+/* extract_uue() compared a part counter that it never incremented, so any
+ * index greater than 0 returned NULL even when the part existed. */
+function uue($name, $data) {
+	return "begin 644 $name\n" . convert_uuencode($data) . "end\n\n";
+}
+$body = "intro line\n\n" . uue("a.txt", "FIRST") . "\n" . uue("b.txt", "SECOND");
+
+$fp = fopen("php://memory", "r+");
+fwrite($fp, $body);
+rewind($fp);
+$m = new MimeMessage("stream", $fp);
+var_dump($m->extract_uue(0, MAILPARSE_EXTRACT_RETURN));
+var_dump($m->extract_uue(1, MAILPARSE_EXTRACT_RETURN));
+var_dump($m->extract_uue(2, MAILPARSE_EXTRACT_RETURN));
+fclose($fp);
+?>
+--EXPECT--
+string(5) "FIRST"
+string(6) "SECOND"
+NULL


### PR DESCRIPTION
## What

`MimeMessage::extract_uue($index, ...)` returns NULL for any `$index >= 1`, so only the first uuencoded attachment in a message is reachable.

The method compares a part counter `nparts` against `$index` but never increments it, unlike the sibling `enum_uue` which does. So `nparts == index` only ever matches index 0.

## Fix

Increment `nparts` after skipping a non-matching part, so the counter advances to the requested index.
